### PR TITLE
Corrected the tests for PUT /signature/:epoch in server.test.ts, whic…

### DIFF
--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -108,32 +108,32 @@ describe.skip("PUT /signatures/:epoch", () => {
     );
   });
 
-  it("calls findSignatureByEpoch with the given epoch", async () => {
+  it("calls updateSignatureByEpoch with the given epoch and property update", async () => {
     await supertest(app)
       .put("/signatures/1614095562950")
       .send(updateProperties);
-    expect(findSignatureByEpoch).toHaveBeenCalledWith(1614095562950);
+    expect(updateSignatureByEpoch).toHaveBeenCalledWith(1614095562950, updateProperties);
   });
 
   test("when updateSignatureByEpoch returns a signature, it returns a 200 with the given epoch", async () => {
     const response = await supertest(app)
       .put(`/signatures/${passingSignature.epochId}`)
       .send(updateProperties);
-    expect(findSignatureByEpoch).toReturnWith({
+    expect(updateSignatureByEpoch).toReturnWith({
       ...passingSignature,
       ...updateProperties,
     });
     expect(response.status).toBe(200);
     expect(response.body.status).toBe("success");
-    expect(response.body.data).toHaveProperty("signature");
+    expect(response.body.data).toHaveProperty("didUpdate");
   });
 
-  test("when updateSignatureByEpoch returns null, it returns a 404 with information about not managing to find a signature", async () => {
+  test("when updateSignatureByEpoch returns null, it returns a 404 with information about not managing to update a signature", async () => {
     // add one to patch a non-passing epochId value
     const response = await supertest(app)
       .put(`/signatures/${passingSignature.epochId + 1}`)
       .send(updateProperties);
-    expect(findSignatureByEpoch).toReturnWith(null);
+    expect(updateSignatureByEpoch).toReturnWith(null);
     expect(response.status).toBe(404);
     expect(response.body.status).toBe("fail");
     expect(response.body.data).toHaveProperty("epochId");

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -115,7 +115,7 @@ describe.skip("PUT /signatures/:epoch", () => {
     expect(updateSignatureByEpoch).toHaveBeenCalledWith(1614095562950, updateProperties);
   });
 
-  test("when updateSignatureByEpoch returns a signature, it returns a 200 with the given epoch", async () => {
+  test("when updateSignatureByEpoch returns a signature, it returns a 200 with the given epoch and full updated signature", async () => {
     const response = await supertest(app)
       .put(`/signatures/${passingSignature.epochId}`)
       .send(updateProperties);
@@ -125,7 +125,7 @@ describe.skip("PUT /signatures/:epoch", () => {
     });
     expect(response.status).toBe(200);
     expect(response.body.status).toBe("success");
-    expect(response.body.data).toHaveProperty("didUpdate");
+    expect(response.body.data).toHaveProperty("signature");
   });
 
   test("when updateSignatureByEpoch returns null, it returns a 404 with information about not managing to update a signature", async () => {


### PR DESCRIPTION
…h were previously written incorrectly